### PR TITLE
Rewrite ohai_plugin.rb to reflect new ohai cookbook version

### DIFF
--- a/recipes/from_package.rb
+++ b/recipes/from_package.rb
@@ -34,9 +34,6 @@ node['dovecot']['packages'].each do |type, pkgs|
     package "(#{type}) #{pkg}" do
       package_name pkg
       only_if { Dovecot::Conf.require?(type, node['dovecot']) }
-      if type == 'core' || node['dovecot']['ohai_plugin']['build-options']
-        notifies :reload, 'ohai[reload_dovecot]', :immediately
-      end
     end # package
   end # pkg.each
 end # node['dovecot']['packages'].each

--- a/recipes/ohai_plugin.rb
+++ b/recipes/ohai_plugin.rb
@@ -23,22 +23,12 @@ def ohai7?
   Gem::Requirement.new('>= 7').satisfied_by?(Gem::Version.new(Ohai::VERSION))
 end
 
+ohai_build_options = node['dovecot']['ohai_plugin']['build-options']
 source_dir = ohai7? ? 'ohai7_plugins' : 'ohai_plugins'
 
-ohai 'reload_dovecot' do
-  plugin 'dovecot'
-  action :nothing
+ohai_plugin 'dovecot' do
+  name 'dovecot'
+  source_file "#{source_dir}/dovecot.rb.erb"
+  resource :template
+  variables enable_build_options: ohai_build_options
 end
-
-template "#{node['ohai']['plugin_path']}/dovecot.rb" do
-  source "#{source_dir}/dovecot.rb.erb"
-  owner 'root'
-  group 'root'
-  mode '0755'
-  variables(
-    enable_build_options: node['dovecot']['ohai_plugin']['build-options']
-  )
-  notifies :reload, 'ohai[reload_dovecot]', :immediately
-end
-
-include_recipe 'ohai::default'

--- a/test/unit/recipes/from_package_spec.rb
+++ b/test/unit/recipes/from_package_spec.rb
@@ -27,12 +27,6 @@ describe 'dovecot::from_package' do
   shared_examples 'any package' do
     context 'with ohai build options enabled' do
       before { node.set['dovecot']['ohai_plugin']['build-options'] = true }
-
-      it 'notifies ohai plugin' do
-        resource = chef_run.package(pkg)
-        expect(resource).to notify('ohai[reload_dovecot]').to(:reload)
-          .immediately
-      end
     end # context with ohai build options enabled
   end # shared example any package
 
@@ -41,12 +35,6 @@ describe 'dovecot::from_package' do
 
     context 'with ohai build options disabled' do
       before { node.set['dovecot']['ohai_plugin']['build-options'] = false }
-
-      it 'notifies ohai plugin' do
-        resource = chef_run.package(pkg)
-        expect(resource).to notify('ohai[reload_dovecot]').to(:reload)
-          .immediately
-      end
     end # context with ohai build options disabled
   end
 
@@ -55,11 +43,6 @@ describe 'dovecot::from_package' do
 
     context 'with ohai build options disabled' do
       before { node.set['dovecot']['ohai_plugin']['build-options'] = false }
-
-      it 'notifies ohai plugin' do
-        resource = chef_run.package(pkg)
-        expect(resource).to_not notify('ohai[reload_dovecot]')
-      end
     end # context with ohai build options disabled
   end
 

--- a/test/unit/recipes/ohai_plugin_spec.rb
+++ b/test/unit/recipes/ohai_plugin_spec.rb
@@ -22,42 +22,7 @@ require_relative '../spec_helper'
 describe 'dovecot::ohai_plugin' do
   let(:chef_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
 
-  it 'creates ohai reload resource' do
-    resource = chef_run.ohai('reload_dovecot')
-    expect(resource).to do_nothing
-  end
-
-  it 'installs dovecot plugin' do
-    expect(chef_run).to create_template('/etc/chef/ohai_plugins/dovecot.rb')
-      .with_owner('root')
-      .with_group('root')
-      .with_mode('0755')
-  end
-
-  it 'dovecot plugin installation notifies ohai reload' do
-    resource = chef_run.template('/etc/chef/ohai_plugins/dovecot.rb')
-    expect(resource).to notify('ohai[reload_dovecot]').to(:reload).immediately
-  end
-
-  context 'with Ohai 6' do
-    before { stub_const('Ohai::VERSION', '6.24.2') }
-
-    it 'uses the template from plugins/' do
-      expect(chef_run).to create_template('/etc/chef/ohai_plugins/dovecot.rb')
-        .with_source('ohai_plugins/dovecot.rb.erb')
-    end
-  end # context with Ohai 6
-
-  context 'with Ohai 7' do
-    before { stub_const('Ohai::VERSION', '7.0.0') }
-
-    it 'uses the template from plugins7/' do
-      expect(chef_run).to create_template('/etc/chef/ohai_plugins/dovecot.rb')
-        .with_source('ohai7_plugins/dovecot.rb.erb')
-    end
-  end # context with Ohai 6
-
-  it 'includes ohai::default recipe' do
-    expect(chef_run).to include_recipe('ohai::default')
+  it 'creates ohai dovecot plugin' do
+    expect(chef_run).to create_ohai_plugin('dovecot')
   end
 end


### PR DESCRIPTION
Ohai plugins should be installed ohai_plugin resource: https://github.com/chef-cookbooks/ohai/blob/master/resources/plugin.rb