### PR TITLE
Added password_query to dovecot-sql.conf.ext

### DIFF
--- a/templates/default/dovecot-sql.conf.ext.erb
+++ b/templates/default/dovecot-sql.conf.ext.erb
@@ -140,6 +140,7 @@
 #  SELECT userid AS user, password, \
 #    home AS userdb_home, uid AS userdb_uid, gid AS userdb_gid \
 #  FROM users WHERE userid = '%u'
+<%= DovecotCookbook::Conf.attribute(@conf['sql'], 'password_query') %>
 
 # Query to get a list of all usernames.
 #iterate_query = SELECT username AS user FROM users


### PR DESCRIPTION
Attribute password_query is still available in conf_dovecot_sql.rb, also appears on the examples. Either remove it or add to the template.

### Description

This PR adds the password_query value to the dovecot-sql.conf.ext.rb template.

### Issues Resolved

None

### Contribution Check List

- [Y] All tests pass.
- [N] New functionality includes testing.
- [N] New functionality has been documented in the README and metadata if applicable.
