### PR TITLE
Update platform list and dependencies to fix converge

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -14,8 +14,6 @@ platforms:
 - name: oraclelinux-6
   driver_config:
     platform: rhel
-- name: ubuntu-15.10
-  run_list: recipe[apt]
 - name: ubuntu-16.04
   run_list: recipe[apt]
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,25 +17,20 @@ provisioner:
 platforms:
 - name: centos-6.7
 - name: centos-7.2
+- name: centos-7.4
 - name: debian-7.9
   run_list: recipe[apt]
 - name: debian-8.2
   run_list: recipe[apt]
 - name: fedora-20
 - name: fedora-21
-- name: opensuse-12.3
+- name: opensuse-42.3
   driver_config:
-    box: opensuse-12.3-64
-    box_url: 'http://downloads.sourceforge.net/project/opensusevagrant/12.3/opensuse-12.3-64.box?r=&ts=1441918998&use_mirror=freefr'
-- name: opensuse-13.2
-  driver_config:
-    box: opscode-opensuse-13.2
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_opensuse-13.2-x86_64_chef-provisionerless.box
+    box: opensuse/openSUSE-42.3-x86_64
+    box_version: 1.0.5.20171128
 - name: ubuntu-12.04
   run_list: recipe[apt]
 - name: ubuntu-14.04
-  run_list: recipe[apt]
-- name: ubuntu-15.10
   run_list: recipe[apt]
 - name: ubuntu-16.04
   run_list: recipe[apt]
@@ -53,8 +48,7 @@ suites:
   - centos-7.2
   - fedora-20
   - fedora-21
-  - opensuse-12.3
-  - opensuse-13.2
+  - opensuse-42.3
   - oraclelinux-6
   - scientific-6.6
   run_list:
@@ -71,12 +65,10 @@ suites:
   - debian-8.2
   - debian-8
   - ubuntu-12.04
-  - ubuntu-15.10
   - ubuntu-16.04
   - fedora-20
   - fedora-21
-  - opensuse-12.3
-  - opensuse-13.2
+  - opensuse-42.3
   - oraclelinux-6
   - scientific-6.6
 

--- a/test/cookbooks/dovecot_test/metadata.rb
+++ b/test/cookbooks/dovecot_test/metadata.rb
@@ -30,5 +30,5 @@ version '0.1.0'
 depends 'dovecot'
 depends 'ldap', '~> 1.0'
 depends 'netstat', '~> 0.1.0' # Required to run integration tests with Docker
-depends 'openldap', '~> 2.1'
+depends 'openldap', '~> 3.1'
 depends 'ssl_certificate', '~> 1.5'

--- a/test/cookbooks/dovecot_test/recipes/ldap.rb
+++ b/test/cookbooks/dovecot_test/recipes/ldap.rb
@@ -40,7 +40,7 @@ node.default['openldap']['tls_enabled'] = false
 node.default['openldap']['rootpw'] = generate_ldap_password(ldap_password)
 node.default['openldap']['loglevel'] = 'any'
 
-include_recipe 'openldap::server'
+include_recipe 'openldap::default'
 
 # Create some LDAP entries as an example
 


### PR DESCRIPTION
### Description

Update platform list and dependencies to fix converge

### Issues Resolved

- Included CentOS-7.4 platform (not an issue)

- OpenSuse 12.3 is [discontinued](https://en.opensuse.org/Lifetime#Discontinued_distributions)
    Repo paths have changed and it fails with
    ```
    File '/repodata/repomd.xml' not found on medium 'http://download.opensuse.org/update/12.3-non-oss/'
    ```
    - [x] Removed `OpenSuse 12.3` and replaced with `OpenSuse 42.3`

- Old version of openldap cookbook was using pakcage name [`db-utils` instead of correct `db4-utils`](https://github.com/chef-cookbooks/openldap/pull/55)
    - [x] Updated metadata to depend upon [`openldap cookbook version 3.1`](https://github.com/chef-cookbooks/openldap/pull/83) and changed include_recipe from `openldap::server` to `openldap::default` 

- Ubuntu 15.10 is not LTS
    15.10 release `update, backports, and security` repositories are not available anymore, thus
build fails. Anyway, in my opinion, servers should deploy only LTS releases anyway
    - [x] Removed ubuntu-15.10 platform
    - [x] Added ubuntu-16.04 platform

### Contribution Check List

- [x] All tests pass.