### PR TITLE
Add support for dovecot stats service

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -14,8 +14,6 @@ platforms:
 - name: oraclelinux-6
   driver_config:
     platform: rhel
-- name: ubuntu-15.10
-  run_list: recipe[apt]
 - name: ubuntu-16.04
   run_list: recipe[apt]
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,25 +17,20 @@ provisioner:
 platforms:
 - name: centos-6.7
 - name: centos-7.2
+- name: centos-7.4
 - name: debian-7.9
   run_list: recipe[apt]
 - name: debian-8.2
   run_list: recipe[apt]
 - name: fedora-20
 - name: fedora-21
-- name: opensuse-12.3
+- name: opensuse-42.3
   driver_config:
-    box: opensuse-12.3-64
-    box_url: 'http://downloads.sourceforge.net/project/opensusevagrant/12.3/opensuse-12.3-64.box?r=&ts=1441918998&use_mirror=freefr'
-- name: opensuse-13.2
-  driver_config:
-    box: opscode-opensuse-13.2
-    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_opensuse-13.2-x86_64_chef-provisionerless.box
+    box: opensuse/openSUSE-42.3-x86_64
+    box_version: 1.0.5.20171128
 - name: ubuntu-12.04
   run_list: recipe[apt]
 - name: ubuntu-14.04
-  run_list: recipe[apt]
-- name: ubuntu-15.10
   run_list: recipe[apt]
 - name: ubuntu-16.04
   run_list: recipe[apt]
@@ -53,8 +48,7 @@ suites:
   - centos-7.2
   - fedora-20
   - fedora-21
-  - opensuse-12.3
-  - opensuse-13.2
+  - opensuse-42.3
   - oraclelinux-6
   - scientific-6.6
   run_list:
@@ -71,12 +65,10 @@ suites:
   - debian-8.2
   - debian-8
   - ubuntu-12.04
-  - ubuntu-15.10
   - ubuntu-16.04
   - fedora-20
   - fedora-21
-  - opensuse-12.3
-  - opensuse-13.2
+  - opensuse-42.3
   - oraclelinux-6
   - scientific-6.6
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Table of Contents
   * [Plugins Examples](#plugins-examples)
     * [Mail Log Plugin Example](#mail-log-plugin-example)
     * [Sieve Plugin Example](#sieve-plugin-example)
+    * [Stats Plugin Example](#stats-plugin-example)
   * [Protocols Examples](#protocols-examples)
   * [Service Examples](#service-examples)
     * [Director Service Example](#director-service-example)
@@ -62,6 +63,7 @@ Table of Contents
     * [Doveadm Service Example](#doveadm-service-example)
     * [Quota-status Service Example](#quota-status-service-example)
     * [Quota-warning Service Example](#quota-warning-service-example)
+    * [Stats Service Example](#stats-service-example)
   * [LDAP Example](#ldap-example)
   * [Password File Example](#password-file-example)
   * [A Complete Example](#a-complete-example)
@@ -127,7 +129,7 @@ To see a more complete description of the attributes, go to the [Dovecot wiki2 c
 | `node['dovecot']['namespaces']`                   | `[]`                       | Dovecot Namespaces as an array of hashes ([see the example below](#namespaces-example)).
 | `node['dovecot']['plugins']`                      | *calculated*               | Dovecot Plugins configuration as a hash of hashes ([see the examples below](#plugins-examples)). Supported plugins: mail_log, acl and quota.
 | `node['dovecot']['protocols']`                    | `{}`                       | Dovecot Protocols configuration as a hash of hashes ([see the example below](#protocols-example)). Supported protocols: lda, imap, lmtp, sieve and pop3.
-| `node['dovecot']['services']`                     | `{}`                       | Dovecot Services configuration as a hash of hashes ([see the examples below](#service-examples)). Supported services: anvil, director, imap-login, pop3-login, lmtp, imap, pop3, auth, auth-worker, dict, tcpwrap, managesieve-login managesieve, quota-status, quota-warning and doveadm.
+| `node['dovecot']['services']`                     | `{}`                       | Dovecot Services configuration as a hash of hashes ([see the examples below](#service-examples)). Supported services: anvil, director, imap-login, pop3-login, lmtp, imap, pop3, auth, auth-worker, dict, tcpwrap, managesieve-login managesieve, quota-status, quota-warning, stats, and doveadm.
 | `node['dovecot']['conf']['mail_plugins']`         | `[]`                       | Dovecot default enabled mail_plugins.
 | `node['dovecot']['ohai_plugin']['build-options']` | `true`                     | Whether to enable reading build options inside ohai plugin. Can be disabled to be lighter.
 | `node['dovecot']['databag_name']`              | `dovecot`                  | The databag to use.
@@ -719,6 +721,19 @@ node.default['dovecot']['plugins']['sieve'] = {
 }
 ```
 
+### Stats Plugin Example
+```ruby
+node.default['dovecot']['plugins']['stats'] = {
+  'stats_refresh' => '60 secs',
+  'stats_memory_limit' => '64 M',
+  'stats_command_min_time' => '5 mins',
+  'stats_session_min_time' => '5 mins',
+  'stats_user_min_time' => '24 hours',
+  'stats_domain_min_time' => '24 hours',
+  'stats_ip_min_time' => '1 hours'
+}
+```
+
 ## Protocols Examples
 
 Protocol attribute values should be of type hash.
@@ -800,6 +815,23 @@ default['dovecot']['services']['quota-warning'] = {
   'executable' => 'script /usr/local/bin/quota-warning.sh',
   'listeners' => [
     { 'unix:quota-warning' => { 'user' => 'postfix' } }
+  ]
+}
+```
+
+### Stats Service Example
+
+```ruby
+default['dovecot']['services']['stats'] = {
+  listeners: [
+    { 'fifo:stats-mail' =>
+      {  user: node['dovecot']['user'],
+         group: node['dovecot']['group'],
+         mode: '0600' } },
+    { 'fifo:stats-user' =>
+      {  user: node['dovecot']['user'],
+         group: node['dovecot']['group'],
+         mode: '0600' } }
   ]
 }
 ```

--- a/templates/default/conf.d/10-master.conf.erb
+++ b/templates/default/conf.d/10-master.conf.erb
@@ -158,3 +158,7 @@ service dict {
 <% if @services['anvil'].kind_of?(Hash) and @services['anvil'].length > 0 -%>
 <%=  DovecotCookbook::Conf.service('anvil', @services['anvil']) %>
 <% end -%>
+
+<% if @services['stats'].kind_of?(Hash) and @services['stats'].length > 0 -%>
+<%=  DovecotCookbook::Conf.service('stats', @services['stats']) %>
+<% end -%>

--- a/test/cookbooks/dovecot_test/metadata.rb
+++ b/test/cookbooks/dovecot_test/metadata.rb
@@ -30,5 +30,5 @@ version '0.1.0'
 depends 'dovecot'
 depends 'ldap', '~> 1.0'
 depends 'netstat', '~> 0.1.0' # Required to run integration tests with Docker
-depends 'openldap', '~> 2.1'
+depends 'openldap', '~> 3.1'
 depends 'ssl_certificate', '~> 1.5'

--- a/test/cookbooks/dovecot_test/recipes/ldap.rb
+++ b/test/cookbooks/dovecot_test/recipes/ldap.rb
@@ -40,7 +40,7 @@ node.default['openldap']['tls_enabled'] = false
 node.default['openldap']['rootpw'] = generate_ldap_password(ldap_password)
 node.default['openldap']['loglevel'] = 'any'
 
-include_recipe 'openldap::server'
+include_recipe 'openldap::default'
 
 # Create some LDAP entries as an example
 


### PR DESCRIPTION
### Description

Adds [stats service](https://wiki2.dovecot.org/Statistics/Old) support 

### Contribution Check List

- [x] All tests pass.
- [x] New functionality has been documented in the README and metadata if applicable.